### PR TITLE
fix(pausing): better initial contract state

### DIFF
--- a/contracts/CellarStaking.sol
+++ b/contracts/CellarStaking.sol
@@ -313,7 +313,7 @@ contract CellarStaking is ICellarStaking, Ownable {
         uint256 sharesToBurn = (totalShares * amountWithBoost) / totalDepositsWithBoost;
 
         if (sharesToBurn == 0) revert USR_UnstakeTooSmall(amount);
-        if (sharesToBurn > s.shares) revert ACCT_TooManySharesBurned(sharesToBurn, s.shares);
+        if (sharesToBurn > s.shares) revert ACCT_TooManySharesBurned(msg.sender, depositId, sharesToBurn, s.shares);
 
         s.shares -= sharesToBurn;
 
@@ -549,6 +549,10 @@ contract CellarStaking is ICellarStaking, Ownable {
      * @param _paused               Whether the contract should be paused.
      */
     function setPaused(bool _paused) external override onlyOwner {
+        if (_paused == true && startTimestamp == 0) {
+            revert STATE_NotInitialized();
+        }
+
         paused = _paused;
     }
 

--- a/contracts/CellarStaking.sol
+++ b/contracts/CellarStaking.sol
@@ -549,7 +549,7 @@ contract CellarStaking is ICellarStaking, Ownable {
      * @param _paused               Whether the contract should be paused.
      */
     function setPaused(bool _paused) external override onlyOwner {
-        if (_paused == true && startTimestamp == 0) {
+        if (_paused == false && startTimestamp == 0) {
             revert STATE_NotInitialized();
         }
 

--- a/contracts/CellarStaking.sol
+++ b/contracts/CellarStaking.sol
@@ -550,9 +550,7 @@ contract CellarStaking is ICellarStaking, Ownable {
      * @param _paused               Whether the contract should be paused.
      */
     function setPaused(bool _paused) external override onlyOwner {
-        if (_paused == false && startTimestamp == 0) {
-            revert STATE_NotInitialized();
-        }
+        if (startTimestamp == 0) revert STATE_NotInitialized();
 
         paused = _paused;
     }

--- a/contracts/CellarStaking.sol
+++ b/contracts/CellarStaking.sol
@@ -376,6 +376,7 @@ contract CellarStaking is ICellarStaking, Ownable {
     {
         // Individually claim for each stake
         uint256[] memory depositIds = allUserStakes[msg.sender];
+        rewards = new uint256[](depositIds.length);
 
         for (uint256 i = 0; i < depositIds.length; i++) {
             rewards[i] = _claim(depositIds[i]);
@@ -468,7 +469,7 @@ contract CellarStaking is ICellarStaking, Ownable {
         if (_numEpochs == 0) revert USR_NoEpochs();
         if (_numEpochs > maxNumEpochs) revert USR_TooManyEpochs(_numEpochs, maxNumEpochs);
         if (_epochLength == 0) revert USR_ZeroEpochLength();
-        if (_rewardsPerEpoch == 0) revert USR_ZeroRewardsPerEpoch();
+        if (_rewardsPerEpoch < _epochLength) revert USR_ZeroRewardsPerEpoch();
 
         // Mark starting point for rewards accounting
         paused = false;
@@ -508,7 +509,7 @@ contract CellarStaking is ICellarStaking, Ownable {
         if (rewardEpochs.length + _numEpochs > maxNumEpochs)
             revert USR_TooManyEpochs(rewardEpochs.length + _numEpochs, maxNumEpochs);
         if (_epochLength == 0) revert USR_ZeroEpochLength();
-        if (_rewardsPerEpoch == 0) revert USR_ZeroRewardsPerEpoch();
+        if (_rewardsPerEpoch < _epochLength) revert USR_ZeroRewardsPerEpoch();
 
         RewardEpoch memory lastEpoch = rewardEpochs[rewardEpochs.length - 1];
         if (lastEpoch.startTimestamp > 0) revert ACCT_NoPreviousEpoch();
@@ -757,7 +758,7 @@ contract CellarStaking is ICellarStaking, Ownable {
                 uint256 totalRewardsEarned = 0;
 
                 // For each epoch in window, calculate rewards
-                for (uint256 j = epochAtLastAccounting; j <= epochNow; i++) {
+                for (uint256 j = epochAtLastAccounting; j <= epochNow; j++) {
                     totalRewardsEarned += _calculateStakeRewardsForEpoch(i, s);
                 }
 

--- a/contracts/Errors.sol
+++ b/contracts/Errors.sol
@@ -101,11 +101,6 @@ error USR_InvalidLockValue(uint256 lock);
 ///     or the progression of time.
 
 /**
- * @notice The caller attempted to perform an action which required the pool to be initialized.
- */
-error STATE_NotInitialized();
-
-/**
  * @notice The caller attempted to initialize the pool more than once.
  */
 error STATE_AlreadyInitialized();

--- a/contracts/Errors.sol
+++ b/contracts/Errors.sol
@@ -13,8 +13,8 @@ pragma solidity >=0.8.4;
 /**
  * @notice User attempted to stake an amount smaller than the minimu deposit.
  *
- * @param amount Amount user attmpted to stake.
- * @param minimumDeposit The minimum deopsit amount accepted.
+ * @param amount                Amount user attmpted to stake.
+ * @param minimumDeposit        The minimum deopsit amount accepted.
  */
 error USR_MinimumDeposit(uint256 amount, uint256 minimumDeposit);
 
@@ -22,7 +22,7 @@ error USR_MinimumDeposit(uint256 amount, uint256 minimumDeposit);
  * @notice Amount user attempted to stake is equivalent to zero staking shares after division.
  * @dev    If this occurs, the admin should look at increasing the minimum deposit size.
  *
- * @param amount The amount of tokens the user attmpted to stake.
+ * @param amount                The amount of tokens the user attmpted to stake.
  */
 error USR_StakeTooSmall(uint256 amount);
 
@@ -34,21 +34,21 @@ error USR_ZeroUnstake();
 /**
  * @notice The specified deposit ID does not exist for the caller.
  *
- * @param depositId The deposit ID provided for lookup.
+ * @param depositId             The deposit ID provided for lookup.
  */
 error USR_NoDeposit(uint256 depositId);
 
 /**
  * @notice The user is attempting to unstake a deposit which is still timelocked.
  *
- * @param depositId The deposit ID the user attempted to unstake.
+ * @param depositId             The deposit ID the user attempted to unstake.
  */
 error USR_StakeLocked(uint256 depositId);
 
 /**
  * @notice The user is attempting to unstake an amount which is equivalent to zero staking shares.
  *
- * @param amount The amount of tokens the user attempted to unstake.
+ * @param amount                The amount of tokens the user attempted to unstake.
  */
 error USR_UnstakeTooSmall(uint256 amount);
 
@@ -61,8 +61,8 @@ error USR_NoEpochs();
  * @notice The contract owner attempted to update rewards but specified too many initial or incremental epochs.
  * @dev    The maximum number of epochs is set at contract creation time and protects against the block gas limit.
  *
- * @param numEpochs The number of reward epochs that would have existed as a result of the call.
- * @param maximum The total allowed number of reward epochs.
+ * @param numEpochs             The number of reward epochs that would have existed as a result of the call.
+ * @param maximum               The total allowed number of reward epochs.
  */
 error USR_TooManyEpochs(uint256 numEpochs, uint256 maximum);
 
@@ -80,7 +80,7 @@ error USR_ZeroRewardsPerEpoch();
  * @notice The contract owner attempted to look up the index of the epoch for the
  *         given timestamp, but there is no reward epoch scheduled for that time.
  *
- * @param timestamp The timestamp for which epoch lookup was attempted.
+ * @param timestamp             The timestamp for which epoch lookup was attempted.
  */
 error USR_NoEpochAtTime(uint256 timestamp);
 
@@ -88,7 +88,7 @@ error USR_NoEpochAtTime(uint256 timestamp);
  * @notice The caller attempted to stake with a lock value that did not
  *         correspond to a valid staking time.
  *
- * @param lock The provided lock value.
+ * @param lock                  The provided lock value.
  */
 error USR_InvalidLockValue(uint256 lock);
 
@@ -99,6 +99,11 @@ error USR_InvalidLockValue(uint256 lock);
 ///
 /// These errors do not relate to user input, and may or may not be resolved by other actions
 ///     or the progression of time.
+
+/**
+ * @notice The caller attempted to unpause the contract, but it is not yet initialized;
+ */
+error STATE_NotInitialized();
 
 /**
  * @notice The caller attempted to initialize the pool more than once.
@@ -160,8 +165,13 @@ error STATE_ContractKilled();
  *         A user's shares should not change, since they are concentrated/diluted by share
  *         minting and burning on other staknig and unstaking actions. This implies an
  *         accounting mistake in tracking total deposits.
+ *
+ * @param user                  The user who attempted to unstake.
+ * @param depositId             The unique ID of the user's stake.
+ * @param sharesToBurn          The amount of shares accounting determined must be burnt.
+ * @param stakeShares           The amount of shares for the given stake. Should be less than sharesToBurn.
  */
-error ACCT_TooManySharesBurned(uint256 sharesToBurn, uint256 stakeShares);
+error ACCT_TooManySharesBurned(address user, uint256 depositId, uint256 sharesToBurn, uint256 stakeShares);
 
 /**
  * @notice The owner attempted to replenish the pool with a new rewards schedule, but the pool
@@ -179,6 +189,10 @@ error ACCT_NoPreviousEpoch();
  *         meaning that reward accumulation accounting was missed for some time window, or an
  *         arithmetic error that led to earned rewards not being correctly accumulated for
  *         the epoch.
+ *
+ * @param epochRewardsEarned    The total rewards accounted for in the epoch.
+ * @param epochTotalRewards     The total rewards predetermined to be distributed over the epoch.
+ *                              Should not equal epochRewardsEarned.
  */
 error ACCT_PastEpochRewards(uint256 epochRewardsEarned, uint256 epochTotalRewards);
 
@@ -189,6 +203,11 @@ error ACCT_PastEpochRewards(uint256 epochRewardsEarned, uint256 epochTotalReward
  *         an issue with funding the distribution token when defining reward schedules, paying
  *         out too much of the token in previously-accounted rewards, or malicious activity
  *         that successfully drained the reward pool.
+ *
+ * @param tokenBalance          The amount of the distribution held by the contract.
+ * @param rewardsLeft           The total rewards amount of rewards scheduled to be released
+ *                              in the future. Should be less than tokenBalance.
+ *
  */
 error ACCT_CannotFundRewards(uint256 tokenBalance, uint256 rewardsLeft);
 
@@ -200,5 +219,8 @@ error ACCT_CannotFundRewards(uint256 tokenBalance, uint256 rewardsLeft);
  *         accounting issue in tracking total deposits, or malicious activity that allowed
  *         a user to mint shares without needing to deposit tokens (or, alternatively, a user
  *         that found a method to withdraw tokens while preserving their shares).
+ *
+ * @param totalShares           The total shares accounted for in the staking contract. Should be nonzero.
+ * @param totalDeposits         The total deposits in the staking contract. Should be zero.
  */
 error ACCT_SharesWithoutDeposits(uint256 totalShares, uint256 totalDeposits);

--- a/contracts/Errors.sol
+++ b/contracts/Errors.sol
@@ -73,6 +73,8 @@ error USR_ZeroEpochLength();
 
 /**
  * @notice The contract owner attempted to update rewards but 0 rewards per epoch.
+ *         This can also happen if there is less than 1 wei of rewards per second of the
+ *         epoch - due to integer division this will also lead to 0 rewards.
  */
 error USR_ZeroRewardsPerEpoch();
 


### PR DESCRIPTION
Fixes/optimizations found during testing:

- Pause contract in constructor, and unpause it `initializePool`, so that staking operations cannot take place before init
- Remove `startTimestamp == 0` checks, since they are now redundant (since pool will be paused if not initialized), except for when unpausing the contract
- Fully document params in `Errors.sol`