### PR TITLE
feat(contract): import from solmate ERC20 instead of openzeppelin

### DIFF
--- a/contracts/CellarStaking.sol
+++ b/contracts/CellarStaking.sol
@@ -1,12 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.10;
 
-import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
-import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
-import "@openzeppelin/contracts/access/Ownable.sol";
-
+import {ERC20} from "@rari-capital/solmate/src/tokens/ERC20.sol";
+import {SafeTransferLib} from "@rari-capital/solmate/src/utils/SafeTransferLib.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {ICellarStaking} from "./interfaces/ICellarStaking.sol";
 import "./Errors.sol";
-import "./interfaces/ICellarStaking.sol";
 
 /**
  * @title Sommelier Staking
@@ -114,7 +113,7 @@ import "./interfaces/ICellarStaking.sol";
  *
  */
 contract CellarStaking is ICellarStaking, Ownable {
-    using SafeERC20 for ERC20;
+    using SafeTransferLib for ERC20;
 
     // ============================================ STATE ==============================================
 

--- a/contracts/interfaces/ICellarStaking.sol
+++ b/contracts/interfaces/ICellarStaking.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.4;
 
-import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import {ERC20} from "@rari-capital/solmate/src/tokens/ERC20.sol";
 
 /**
  * @title Sommelier Staking Interface

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@nomiclabs/hardhat-ethers": "^2.0.2",
     "@nomiclabs/hardhat-etherscan": "^2.1.8",
     "@nomiclabs/hardhat-waffle": "^2.0.1",
+    "@openzeppelin/contracts": "^4.5.0",
     "@typechain/ethers-v5": "^8.0.5",
     "@typechain/hardhat": "^3.0.0",
     "@types/chai": "^4.2.22",
@@ -89,7 +90,6 @@
     "typechain": "cross-env TS_NODE_TRANSPILE_ONLY=true hardhat typechain"
   },
   "dependencies": {
-    "@openzeppelin/contracts": "^4.4.1",
     "@rari-capital/solmate": "^6.2.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1514,7 +1514,7 @@ __metadata:
     "@nomiclabs/hardhat-ethers": ^2.0.2
     "@nomiclabs/hardhat-etherscan": ^2.1.8
     "@nomiclabs/hardhat-waffle": ^2.0.1
-    "@openzeppelin/contracts": ^4.4.1
+    "@openzeppelin/contracts": ^4.5.0
     "@rari-capital/solmate": ^6.2.0
     "@typechain/ethers-v5": ^8.0.5
     "@typechain/hardhat": ^3.0.0
@@ -1735,10 +1735,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@openzeppelin/contracts@npm:^4.4.1":
-  version: 4.4.1
-  resolution: "@openzeppelin/contracts@npm:4.4.1"
-  checksum: 87ee7ebe8e6493fc4d657b05c5ddb5f254b73bf55d80c25a790f8e74087b6d90c0a6ec504fe45949c27501f73bca7d64129aad29488707a2c9b5afdb035966df
+"@openzeppelin/contracts@npm:^4.5.0":
+  version: 4.5.0
+  resolution: "@openzeppelin/contracts@npm:4.5.0"
+  checksum: 1c9c5dff041905771d2a83ac29c64dbf0b48603de43f74a34fb1358813d7c7bf259efe2f64e2112b410c5cca7a0b41aaedd882368be5f01a6d50a3ee0740f962
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Use Solmate's ERC20 instead of OpenZeppelin for EIP-2612 support and uniformity with cellar contracts.