### PR TITLE
feat(info): replace `numStakes` with `getUserStakes`

### DIFF
--- a/contracts/CellarStaking.sol
+++ b/contracts/CellarStaking.sol
@@ -201,14 +201,16 @@ contract CellarStaking is ICellarStaking, Ownable {
         (uint256 boost, ) = _getBoost(lock);
         uint256 amountWithBoost = amount + ((amount * boost) / ONE);
 
-        stakes[msg.sender].push(UserStake({
-            amount: amount,
-            amountWithBoost: amountWithBoost,
-            rewardPerTokenPaid: rewardPerTokenStored,
-            rewards: 0,
-            unbondTimestamp: 0,
-            lock: lock
-        }));
+        stakes[msg.sender].push(
+            UserStake({
+                amount: amount,
+                amountWithBoost: amountWithBoost,
+                rewardPerTokenPaid: rewardPerTokenStored,
+                rewards: 0,
+                unbondTimestamp: 0,
+                lock: lock
+            })
+        );
 
         // Update global state
         totalDeposits += amount;
@@ -631,10 +633,7 @@ contract CellarStaking is ICellarStaking, Ownable {
      * @return timestamp           The latest time to calculate.
      */
     function latestRewardsTimestamp() public view override returns (uint256) {
-        return
-            block.timestamp < endTimestamp
-                ? block.timestamp
-                : endTimestamp;
+        return block.timestamp < endTimestamp ? block.timestamp : endTimestamp;
     }
 
     /**
@@ -650,21 +649,22 @@ contract CellarStaking is ICellarStaking, Ownable {
 
         uint256 timeElapsed = latestRewardsTimestamp() - lastAccountingTimestamp;
         uint256 rewardsForTime = timeElapsed * rewardRate;
-        uint256 newRewardsPerToken = rewardsForTime * ONE / totalDepositsWithBoost;
+        uint256 newRewardsPerToken = (rewardsForTime * ONE) / totalDepositsWithBoost;
 
         return rewardPerTokenStored + newRewardsPerToken;
     }
 
     /**
-     * @notice Returns the number of stakes for a user. Can be used off-chain to
-     *         make iterating through user stakes easier.
+     * @notice Gets all of a user's stakes.
+     * @dev This is provided because Solidity converts public arrays into index getters,
+     *      but we need a way to allow external contracts and users to access the whole array.
+
+     * @param user                      The user whose stakes to get.
      *
-     * @param user                      The user to count stakes for.
-     *
-     * @return stakes                   The number of stakes for the user.
+     * @return stakes                   Array of all user's stakes
      */
-    function numStakes(address user) public view override returns (uint256) {
-        return stakes[user].length;
+    function getUserStakes(address user) public view override returns (UserStake[] memory) {
+        return stakes[user];
     }
 
     // ============================================ HELPERS ============================================

--- a/contracts/interfaces/ICellarStaking.sol
+++ b/contracts/interfaces/ICellarStaking.sol
@@ -113,5 +113,5 @@ interface ICellarStaking {
 
     function rewardPerToken() external view returns (uint256);
 
-    function numStakes(address user) external view returns (uint256);
+    function getUserStakes(address user) external view returns (UserStake[] memory);
 }

--- a/test/CellarStaking.ts
+++ b/test/CellarStaking.ts
@@ -10,24 +10,22 @@ import type { CellarStaking } from "../src/types/CellarStaking";
 import type { MockERC20 } from "../src/types/MockERC20";
 import { Block } from "@ethersproject/providers";
 import {
-    ether,
-    deploy,
-    TestContext,
-    increaseTime,
-    rand,
-    shuffle,
-    setNextBlockTimestamp,
-    expectRoundedEqual,
-    claimWithRoundedRewardCheck,
-    setupAdvancedScenario1,
-    setupAdvancedScenario2,
-    runScenario,
-    fundAndApprove,
-    setupAdvancedScenario3,
-    setupAdvancedScenario4
+  ether,
+  deploy,
+  TestContext,
+  increaseTime,
+  rand,
+  shuffle,
+  setNextBlockTimestamp,
+  expectRoundedEqual,
+  claimWithRoundedRewardCheck,
+  setupAdvancedScenario1,
+  setupAdvancedScenario2,
+  runScenario,
+  fundAndApprove,
+  setupAdvancedScenario3,
+  setupAdvancedScenario4,
 } from "./utils";
-
-
 
 const oneDaySec = 60 * 60 * 24;
 const oneWeekSec = oneDaySec * 7;
@@ -1797,11 +1795,11 @@ describe("CellarStaking", () => {
         expect(stake3.lock).to.equal(lockTwoWeeks);
       });
 
-      it("should report the correct number of user stakes", async () => {
+      it("should report all a user's stakes", async () => {
         const { stakingUser, user } = ctx;
 
-        const numStakes = await stakingUser.numStakes(user.address);
-        expect(numStakes).to.equal(3);
+        const userStakes = await stakingUser.getUserStakes(user.address);
+        expect(userStakes.length).to.equal(3);
       });
     });
   });
@@ -2055,5 +2053,5 @@ describe("CellarStaking", () => {
         await expect(staking.connect(reward.signer).unstakeAll()).to.not.be.reverted;
       }
     });
-  })
+  });
 });


### PR DESCRIPTION
Since Solidity converts public arrays into index getters, we needed a way to allow external contracts and UI's to access the whole array of user stakes. Originally, we implemented `numStakes` to help with this. But realized it would be easier to just implement a view function that returns  `stakes[user]` directly. If a contract/UI wanted to get the number of stakes, they could still do so by simply getting the `.length` property on it.

A [similar function](https://github.com/PeggyJV/cellar-contracts/pull/10/commits/9aa46f29fd470bab8efdf93d8aee9588d0cf7167#diff-28f2901b360d238756c690d929a4dd3682bbabe86fa361cb56d0cae6cf8284aeR573) is also implemented in the cellar, so this would also make it more uniform with the cellar.